### PR TITLE
fix invalid time being set when `Time.set(Time)` is being called on itself

### DIFF
--- a/src/com/android/calendarcommon2/Time.java
+++ b/src/com/android/calendarcommon2/Time.java
@@ -147,6 +147,10 @@ public class Time {
     }
 
     public void set(Time other) {
+        if (this == other) {
+            // no-op when being called on itself, see Etar-Group/Etar-Calendar#1151
+            return;
+        }
         clearCalendar();
         mCalendar.setTimeZone(other.getTimeZone());
         mCalendar.setTimeInMillis(other.mCalendar.getTimeInMillis());


### PR DESCRIPTION
see Etar-Group/Etar-Calendar#1151